### PR TITLE
Fix rmagick require: `require "RMagick"` is deprecated

### DIFF
--- a/lib/grobber.rb
+++ b/lib/grobber.rb
@@ -3,6 +3,6 @@ module Grobber
   require 'grobber/square_matrix'
   require 'grobber/image'
   require 'digest'
-  require 'RMagick'
+  require 'rmagick'
 
 end


### PR DESCRIPTION
This removes the warning we always get when using this gem:
```
[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead
```